### PR TITLE
Fix: Sensor MQ 131 ozone conversion from ppb to ug/m3 according to standard

### DIFF
--- a/src/sensornode/sensing_module/sensing_module.py
+++ b/src/sensornode/sensing_module/sensing_module.py
@@ -78,7 +78,7 @@ class SensingModule:
 
             # Reads MQ131
             ozone = self._mq131.get_ozone(
-                current_humidity=humidity, current_temperature=temperature, current_pressure=pressure)
+                current_humidity=humidity, current_temperature=temperature)
 
             # Boilerplate
             pm2_5 = None


### PR DESCRIPTION
# Fix issue #2 
- Fix the conversion to adopt standard parameters according to CONAMA 491/2018
considering temperature as 25°C and pressure as 760mmHg (=1013.2051 hectPa = 1 atm).
- Remove the pressure parameter from the ozone method, since it is not necessary anymore.